### PR TITLE
Correção Final: Construtor Vazio e Método Duplicado

### DIFF
--- a/java/Credential.java
+++ b/java/Credential.java
@@ -8,6 +8,9 @@ public class Credential {
     private String added_at;
     private String last_validated;
 
+    // Default constructor
+    public Credential() {}
+
     // Add a constructor for simpler credential creation
     public Credential(String server, String username, String password) {
         this.server = server;

--- a/java/XtreamClient.java
+++ b/java/XtreamClient.java
@@ -78,11 +78,6 @@ public class XtreamClient {
         Log.d(TAG, "Credentials set for server: " + (credential != null ? credential.getServer() : "null"));
     }
     
-    // Method to get current credentials
-    public Credential getCurrentCredentials() {
-        return currentCredential;
-    }
-    
     // Method for SharedViewModel compatibility
     public Credential getCurrentCredential() {
         return currentCredential;


### PR DESCRIPTION
• Restaurado construtor vazio Credential() necessário para HostActivity
• Removido método getCurrentCredential() duplicado no XtreamClient
• Mantidos todos os construtores necessários: vazio, simples (3 params) e completo (6 params)
• Resolvidos os últimos 3 erros de compilação
• Projeto agora compila sem erros e suporta todos os fluxos de credenciais

₍ᐢ•(ܫ)•ᐢ₎ Generated by [Scout](https://scout.new) ([view jam](https://scout.new/jam/2c916a4a-a126-441e-a685-62058954db25))